### PR TITLE
Fix cdb broadcast panic

### DIFF
--- a/src/backend/execution_unit.rs
+++ b/src/backend/execution_unit.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::rc::Rc;
+use structopt::clap::value_t;
 
 use crate::backend::backend::CDBBroadcast;
 use crate::backend::physical_register::PhysRegFile;
@@ -54,7 +55,7 @@ impl EU {
 
         if self.trace {
             let instr = rob_slot.instr.as_ref().unwrap();
-            println!("Executing {}", instr);
+            println!("Executing [{}]", instr);
         }
 
         match &mut rs.instr {
@@ -67,7 +68,7 @@ impl EU {
     }
 
     fn execute_printr(&mut self, printr: &mut RSPrintr) {
-        println!("PRINTR {}={}", RegisterTypeDisplay { register: printr.rn.arch_reg }, printr.rn.value.unwrap())
+        println!("PRINTR {}={}", RegisterTypeDisplay { register: printr.rn.arch_reg }, printr.rn.value.unwrap());
     }
 
     fn execute_data_processing(&mut self, data_processing: &mut RSDataProcessing, rob_slot: &mut ROBSlot) {
@@ -140,6 +141,7 @@ impl EU {
         let mut phys_reg_file = self.phys_reg_file.borrow_mut();
         let rd = data_processing.rd.phys_reg.unwrap();
         let phys_reg_entry = phys_reg_file.get_mut(rd);
+
         self.broadcast_buffer.borrow_mut().push(CDBBroadcast { phys_reg: rd, value: phys_reg_entry.value });
     }
 

--- a/src/backend/physical_register.rs
+++ b/src/backend/physical_register.rs
@@ -73,7 +73,6 @@ impl PhysRegFile {
             debug_assert!(entry.state == PhysRegEntryState::IDLE);
             debug_assert!(!entry.has_value, " The allocated physical register {} should not have a value", reg);
             entry.state = PhysRegEntryState::BUSY;
-            //println!("Phys Register: allocate {}",reg);
             return reg;
         } else {
             panic!("No free PhysReg")
@@ -92,8 +91,6 @@ impl PhysRegFile {
     }
 
     pub(crate) fn deallocate(&mut self, reg: RegisterType) {
-        // println!("Phys Register: deallocate {}",reg);
-
         debug_assert!(!self.free_stack.contains(&reg), "Phys register {} can't be deallocated while it is also on the free stack", reg);
 
         let entry = self.get_mut(reg);

--- a/src/backend/reorder_buffer.rs
+++ b/src/backend/reorder_buffer.rs
@@ -7,8 +7,10 @@ use crate::instructions::instructions::Instr;
 pub(crate) enum ROBSlotState {
     // the initial state
     IDLE,
-    // the instruction is issued into the rob
+    // the instruction is issued into the rob where it is waiting for its operands.
     ISSUED,
+    // todo: better name, the rob slot has all operands ready but isn't dispatched yet
+    STAGED,
     // the instruction is dispatched to an EU where it will be processed
     DISPATCHED,
     // the instruction has executed


### PR DESCRIPTION
The problem was the double setting the value on the reservation station due to reuse of physical registers.

The solution is to add a check if the value is already set. Once it is set, its physical register is meaningless due to physical register reuse and this will protect against setting the value again.

Fixes https://github.com/pveentjer/Rust-based-ARM-emulator/issues/3